### PR TITLE
Define OWNER_ID constant

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -4,7 +4,7 @@ import logging
 
 from discord import app_commands
 from discord.ext import commands
-from config import client, perform_sync
+from config import client, perform_sync, OWNER_ID
 from core.utils import log_command_usage, check_permissions, get_embed_colour, DB_PATH
 
 
@@ -21,8 +21,7 @@ class AdminCog(commands.Cog):
         self.bot = bot
 
     async def owner_check(self, interaction: discord.Interaction):
-        owner_id = 111941993629806592
-        return interaction.user.id == owner_id
+        return interaction.user.id == OWNER_ID
 
     # ---------------------------------------------------------------------------------------------------------------------
     @app_commands.command(description="Owner: Reset a specific table in the database")

--- a/cogs/customisation.py
+++ b/cogs/customisation.py
@@ -6,6 +6,7 @@ from discord.ext import commands
 from discord.ext.commands import has_permissions
 
 from core.utils import log_command_usage, check_permissions, DB_PATH
+from config import OWNER_ID
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -39,8 +40,7 @@ class CustomisationCog(commands.Cog):
         self.bot = bot
 
     async def owner_check(self, interaction: discord.Interaction):
-        owner_id = 111941993629806592
-        return interaction.user.id == owner_id
+        return interaction.user.id == OWNER_ID
 
     # ---------------------------------------------------------------------------------------------------------------------
     @app_commands.command(description="Owner: Change the bot's avatar.")

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -10,6 +10,7 @@ from discord.ui import View, Button
 from datetime import datetime
 
 from core.utils import log_command_usage, check_permissions, get_embed_colour, DB_PATH
+from config import OWNER_ID
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Logging Configuration
@@ -106,8 +107,7 @@ class UtilityCog(commands.Cog):
         return True
 
     async def owner_check(self, interaction: discord.Interaction):
-        owner_id = 111941993629806592
-        return interaction.user.id == owner_id
+        return interaction.user.id == OWNER_ID
 
 
     # ---------------------------------------------------------------------------------------------------------------------

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ DISCORD_PREFIX = "%"
 
 # Other External Keys
 LAUNCH_TIME = datetime.utcnow()
+OWNER_ID = 111941993629806592
 
 # Login Clients
 intents = discord.Intents.default()


### PR DESCRIPTION
## Summary
- add `OWNER_ID` constant to `config.py`
- reference `OWNER_ID` in admin, customisation, and utility cogs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f9ff0276083239ca62f3a2714245e